### PR TITLE
Fix pre-existing lp_utils test failures (determinism + correctness)

### DIFF
--- a/test/lp_utils.jl
+++ b/test/lp_utils.jl
@@ -1,22 +1,36 @@
 # Testing of the linear programming utilities in CatalystNetworkAnalysis
 
 import CatalystNetworkAnalysis as C
+using StableRNGs
+
 # Test that matrices with positive element in their image space are identified.
 let
-    a = rand(1:10, 10, 10)
+    rng = StableRNG(1234)
+
+    # A full-rank matrix has image space all of Rᵐ, so it admits a positive solution.
+    # `rand(1:10, ...)` is entrywise positive, so this is true unconditionally.
+    a = rand(rng, 1:10, 10, 10)
     @test C.has_positive_solution(a)
 
-    b = -rand(1:10, 10, 10)
+    # An entrywise-negative random 10×10 matrix is full rank with overwhelming
+    # probability; full rank ⟹ image space is Rᵐ ⟹ a positive solution exists.
+    # The seed above pins the draw so this is deterministic.
+    b = -rand(rng, 1:10, 10, 10)
     @test C.has_positive_solution(b)
 
+    # `[1 -1; -1 1]` has column space spanned by `[1, -1]`; every image vector has
+    # entries summing to zero, so it can never dominate `ones`. ⟹ no positive solution.
     a = [1 -1; -1 1]
-    @test !C.has_positive_solution(b)
+    @test !C.has_positive_solution(a)
 
+    # Columns of this 4×4 matrix sum to zero, so every image vector's entries sum to
+    # zero and can never dominate `ones` ⟹ no strictly-positive solution. The zero
+    # vector is a valid non-negative solution, so the `nonneg` variant is satisfied.
     b = [
-        -1 1 1 1;
-        1 -1 1 1;
-        1 1 -1 1
-        1 1 1 -1
+        -3 1 1 1;
+        1 -3 1 1;
+        1 1 -3 1
+        1 1 1 -3
     ]
     @test !C.has_positive_solution(b)
     @test C.has_positive_solution(b, nonneg = true)


### PR DESCRIPTION
## Summary

This fixes the **2 pre-existing `lp_utils` test failures** on `main`. These are
not caused by any dependency bump — they reproduce identically on a clean,
unmodified `main` checkout and were surfaced during triage of bump PR #61
(independent of the bump itself).

**Please ignore until reviewed by @ChrisRackauckas.**

## What was failing on clean `main`

Running `Pkg.test()` on unmodified `main` (Julia 1.11) gives **6 failures**:

```
Test Summary:                  | Pass  Fail  Total
Linear programming utilities   |   3     2      5
Network Translation            |  80     4     84
```

This PR fixes the **2 `Linear programming utilities`** failures. The 4
`Network Translation` failures are a **separate algorithm-correctness bug, not a
determinism/flake issue** — see the "Out of scope" section below for the full
investigation. I did **not** mask them (no skip / `@test_broken` / loosened
assertions / changed expected values).

## Root cause + fix (lp_utils)

`has_positive_solution(M)` looks for `x` with `M*x ≥ ones` (a strictly-positive
vector in the image space). Two assertions in `test/lp_utils.jl` were wrong
against that definition, and two more used unseeded `rand`:

1. **Line 13** asserted `!has_positive_solution(b)` where `b = -rand(1:10,10,10)`
   — but that same `b` had just been asserted to *have* a positive solution on
   line 10 (an entrywise-negative full-rank matrix spans `Rᵐ`, so it does). The
   assertion clearly intended the rank-deficient `a = [1 -1; -1 1]` defined on
   the line directly above it, whose column space (`span([1,-1]`) has entries
   summing to zero and so can never dominate `ones`. Fixed to test `a`.

2. **Line 21**'s 4×4 literal `[-1 1 1 1; 1 -1 1 1; 1 1 -1 1; 1 1 1 -1]` is
   `J − 2I`, which is **full rank** (eigenvalues `2, −2, −2, −2`), so it *does*
   admit a positive solution and `!has_positive_solution` was false. Replaced
   with `J − 4I` = `[-3 1 1 1; …]`, whose columns sum to zero ⟹ every image
   vector's entries sum to zero ⟹ no strictly-positive solution, while the zero
   vector keeps the `nonneg = true` variant (line 22) satisfied.

3. Seeded the two random matrices with `StableRNG(1234)` (already a test dep)
   so the draws are deterministic.

Each replacement matrix's property was verified by calling the actual
`has_positive_solution` on it:

```
a = [1 -1; -1 1]                       has_positive_solution=false  nonneg=true
[-3 1 1 1; 1 -3 1 1; 1 1 -3 1; …]      has_positive_solution=false  nonneg=true
(orig) [-1 1 1 1; … ] (J-2I, rank 4)   has_positive_solution=true   ← why L21 failed
```

## Verification (run locally, Julia 1.11)

`Pkg.test()` after the fix:

```
Test Summary:                  | Pass  Fail  Total
Linear programming utilities   |   5            5     ← was 3/2, now all pass
```

Determinism: the random matrices are now drawn from a fixed `StableRNG(1234)`
seed (identical every run), and the other assertions use literal matrices, so
the testset is deterministic by construction. Confirmed green in a full suite run.

## Out of scope: the 4 `Network Translation` failures are a real algorithm bug

I investigated these thoroughly because the triage hypothesis was that they were
`Set`-iteration-order non-determinism in `WRDZ_translation` (`src/translated.jl`).
**They are not a determinism problem.** Evidence (all run locally, Julia 1.11):

- `construct_rr_graph(zigzag)` is fully deterministic across separate processes
  (identical hash `9913825316295749839`, sum 37) — the MIP solve is stable.
- The `Λ` BFS over that graph assigns a **consistent** offset to every reaction
  regardless of which predecessor reaches it (predecessor-disagreement count = 0).
- Forcing the `Set` traversal into a canonical sorted order (ascending *and*
  descending seed/frontier) yields the **same** result as the default order.

The translations produced are simply **not faithful** — they violate the
defining identity `Y_T * D_T == S` (net stoichiometry) — so the failures are
correctness bugs, not flakes:

```
network   nc   l   rank(S)   effdef   weakly-rev   Y_T*D_T == S
kinase     3   1     2          0        true          true     ← passes
zigzag    13   2     9          2        false         false    ← L92/L93 fail
MAPK       9   1     8          0        false         false    ← L150/L152 fail
```

- **zigzag** (L92 `effectivedeficiency == 0` → evaluates `2 == 0`; L93
  `isweaklyreversible`): the reaction-reaction graph splits into two components;
  each is seeded with an independent `Λ = 0` baseline, but the components share
  complexes, so shared complexes get translated inconsistently. The columns
  where `Y_T*D_T ≠ S` are exactly the second component's reactions (11–16).
- **MAPK** (L150 `Y_T*D_T == netstoichmat(MAPK)`; L152 `isweaklyreversible`):
  single-component, yet still `Y_T*D_T ≠ S`, so there is at least a second,
  distinct defect in the translation construction.

These expected values (`effdef = 0`, weakly reversible, `Y_T*D_T == S`) are the
correct mathematical properties of a valid WRDZ translation, so changing them to
match the buggy output would be masking a real regression — explicitly avoided.
Fixing `WRDZ_translation` correctly requires reworking the multi-component /
shared-complex translation logic (Johnston 2018) and is left for a separate,
focused PR. (Aside: `src/translated.jl` also has two stray `display(...)` debug
calls at lines 86 and 100 that spam stdout during tests — worth removing in that
follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
