### PR TITLE
Fix WRDZ network translation for complexes that split under translation

### DIFF
--- a/src/translated.jl
+++ b/src/translated.jl
@@ -40,7 +40,6 @@ function WRDZ_translation(rn::ReactionSystem)
     isnothing(rr_adj) && return nothing
 
     Y_K = complexstoichmat(rn)
-    Y_T = copy(Y_K)
     D = incidencemat(rn, sparse = true)
 
     nums = size(Y_K, 1)
@@ -83,34 +82,33 @@ function WRDZ_translation(rn::ReactionSystem)
         !isempty(P1) && @goto step_2
         break
     end
-    display(Λ)
+    # Each reaction i is translated by adding the complex Λ[:, i] to both its
+    # source and product. A complex shared by reactions with different
+    # translations therefore splits into distinct translated complexes, so the
+    # translated complexes are built from the per-reaction endpoints rather than
+    # by shifting each original complex once.
+    transl_src = [Y_K[:, rcmap[i].first] .+ Λ[:, i] for i in 1:numr]
+    transl_prd = [Y_K[:, rcmap[i].second] .+ Λ[:, i] for i in 1:numr]
 
-    # Update the Y_T by adding the translation complexes
-    translated = Set{Int}()
+    complexes = unique(vcat(transl_src, transl_prd))
+    _Y_T = reduce(hcat, complexes)
+
+    D_T = zeros(Int, length(complexes), numr)
     for i in 1:numr
-        s = rcmap[i].first
-        p = rcmap[i].second
-
-        s ∈ translated || @. Y_T[:, s] += Λ[:, i]
-        p ∈ translated || @. Y_T[:, p] += Λ[:, i]
-        push!(translated, s, p)
+        D_T[findfirst(==(transl_src[i]), complexes), i] = -1
+        D_T[findfirst(==(transl_prd[i]), complexes), i] = 1
     end
 
-    _Y_T = reduce(hcat, unique(eachcol(Y_T)))
-    display(_Y_T)
-
+    # Map each original complex to a translated complex by its first appearance
+    # as a reaction endpoint (a complex that splits keeps one representative).
     translatedcmap = zeros(Int, numc)
-    for i in 1:numc
-        j = findfirst(==(Y_T[:, i]), eachcol(_Y_T))
-        translatedcmap[i] = j
-    end
-
-    D_T = zeros(Int, size(_Y_T, 2), numr)
     for i in 1:numr
         s = rcmap[i].first
         p = rcmap[i].second
-        D_T[translatedcmap[s], i] = -1
-        D_T[translatedcmap[p], i] = 1
+        translatedcmap[s] == 0 &&
+            (translatedcmap[s] = findfirst(==(transl_src[i]), complexes))
+        translatedcmap[p] == 0 &&
+            (translatedcmap[p] = findfirst(==(transl_prd[i]), complexes))
     end
 
     # If any final complexes are not non-negative, add a pseudo-complex to each member of the linkage class

--- a/test/network_translation.jl
+++ b/test/network_translation.jl
@@ -88,7 +88,7 @@ let
     end
 
     translation = C.WRDZ_translation(zigzag)
-    #@test translation.Y_T * translation.D_T == netstoichmat(zigzag)
+    @test translation.Y_T * translation.D_T == netstoichmat(zigzag)
     @test C.effectivedeficiency(translation) == 0
     @test C.isweaklyreversible(translation)
 end


### PR DESCRIPTION
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Fixes the four pre-existing failures in the `Network Translation` test set (`test/network_translation.jl:92,93,150,152`), which fail on `main` independent of any dependency bump.

### Root cause
`WRDZ_translation` computes a translation offset **per reaction**: reaction `i: sᵢ → pᵢ` becomes `(sᵢ + Λ[:,i]) → (pᵢ + Λ[:,i])`. But it then built the translated complex‑composition matrix `Y_T` **per original complex**, adding `Λ[:,i]` to each complex's column with first‑reaction‑wins:

```julia
s ∈ translated || @. Y_T[:, s] += Λ[:, i]   # only the first reaction touching complex s applies its offset
```

When a complex is the source/product of several reactions with **different** offsets, it must *split* into distinct translated complexes. The per‑complex construction can't represent that — it kept one offset and mapped every reaction sharing the complex to the same translated complex. The result didn't preserve net stoichiometry (`Y_T·D_T ≠ netstoichmat`) and was neither weakly reversible nor deficiency‑zero for branched networks (MAPK, zigzag). Simple single‑cycle networks (kinase) have no shared‑complex/offset conflict, so they happened to pass — which is exactly the observed pattern (kinase ✓, zigzag/MAPK ✗).

### Fix
Build the translated complexes from the **per‑reaction endpoints** (`Y_K[:,sᵢ] + Λ[:,i]` and `Y_K[:,pᵢ] + Λ[:,i]`) and dedup, so complex splitting is represented correctly; `D_T` then points each reaction's translated source/product at the right complex index. Also:
- removed two leftover `display(Λ)` / `display(_Y_T)` debug calls,
- removed the now‑unused `Y_T = copy(Y_K)`,
- re‑enabled the `zigzag` `Y_T·D_T == netstoichmat` assertion (line 91) that had been commented out because it failed.

### Verification (local, Julia 1.11)
`@safetestset "Network Translation"` goes from **4 failures → 85/85 passing**. Directly checked for all three test networks:

| network | `Y_T·D_T == netstoichmat` | effective deficiency | weakly reversible |
|---|---|---|---|
| kinase | ✓ | 0 | ✓ |
| zigzag | ✓ | 0 | ✓ |
| MAPK | ✓ | 0 | ✓ |

The change is confined to `WRDZ_translation` (only consumed by these tests); no other test set touches it. Runic‑clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
