### PR TITLE
Restore contents:write permission for docs deploy (fix gh-pages 403)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,5 +11,9 @@ concurrency:
 jobs:
   docs:
     name: "Documentation"
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The Documentation **deploy** fails on `main`. The docs **build** succeeds — the failure is in the `deploydocs` step, which pushes to `gh-pages` and gets a 403 / "Permission denied" (GITHUB_TOKEN cannot push).

## Root cause

- This repo has **no `DOCUMENTER_KEY` secret**, so Documenter's `deploydocs` falls back to pushing to `gh-pages` via `GITHUB_TOKEN`.
- The CI-centralization migration replaced the old docs job with a thin caller of `SciML/.github/.github/workflows/documentation.yml@v1` and **dropped the `permissions:` block** from the caller `docs` job.
- The reusable workflow declares no workflow-level `permissions`, so for a `uses:` reusable-workflow job the **caller** job's permissions (now the default, read-only `contents`) flow through to the `GITHUB_TOKEN` used inside the called workflow. A read-only token cannot push to `gh-pages` → 403.

## Fix

Add `permissions: { actions: write, contents: write, statuses: write }` to the caller `docs` job in `.github/workflows/Documentation.yml`. This restores the token-based deploy mechanism the repo depends on (no `DOCUMENTER_KEY` required). Mirrors the proven fix in SciML/OrdinaryDiffEqOperatorSplitting.jl#90 exactly.

```yaml
  docs:
    name: "Documentation"
    permissions:
      actions: write
      contents: write
      statuses: write
    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
    secrets: "inherit"
```

## Verification

- YAML validated locally with `python3 yaml.safe_load` (parses; the `docs` job carries the three permissions).
- The deploy itself cannot be fully verified without a CI run on `main` (the gh-pages push only happens on a real `main`/tag run). The change is correct by matching the proven #90 pattern: it grants the caller job the same `contents: write` (plus `actions`/`statuses` write) that the reusable workflow needs to flow into the `GITHUB_TOKEN`.

This does not disable the docs check or set `warnonly`.

Please ignore until reviewed by @ChrisRackauckas