### PR TITLE
Remove undefined steady-state export

### DIFF
--- a/docs/src/Algorithms.md
+++ b/docs/src/Algorithms.md
@@ -41,6 +41,7 @@ CatalystNetworkAnalysis.hasuniquesteadystates
 # Catalyst.iscomplexbalanced
 # Catalyst.isdetailedbalanced
 CatalystNetworkAnalysis.mixedvolume
+SFR
 isconcordant
 deficiencyonealgorithm
 ```
@@ -60,6 +61,9 @@ It is not currently possible to conclusively determine persistence in every case
 ```@docs
 ispersistent
 minimalsiphons
+iscritical
+isconservative
+isconsistent
 ```
 
 The Petri net algorithm relies on detecting siphons in the network, which follows a SAT-solver approach[^5] [^6].
@@ -75,6 +79,13 @@ Like persistence, absolute concentration robustness currently cannot be detected
 
 ```@docs
 isconcentrationrobust
+```
+
+## Network Translation and Flux Modes
+
+```@docs
+elementary_flux_modes
+WRDZ_translation
 ```
 
 Misc references[^9] [^10] [^11] [^12] [^13] [^14] [^15] [^16] [^17] [^18].

--- a/src/CatalystNetworkAnalysis.jl
+++ b/src/CatalystNetworkAnalysis.jl
@@ -40,6 +40,6 @@ include("cycles.jl")
 export elementary_flux_modes
 
 include("translated.jl")
-export WRDZ_translation, symbolic_steady_states
+export WRDZ_translation
 
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -6,7 +6,6 @@ using Test
 # https://github.com/SciML/CatalystNetworkAnalysis.jl/issues/70
 #
 # aqua_broken sub-checks (tracked in issue #70):
-#   undefined_exports: symbolic_steady_states exported but flagged undefined
 #   stale_deps: ReactionNetworkImporters, PolynomialRoots, ModelingToolkit, SBMLToolkit
 #
 # jet_broken: ~14 possible errors (report mode + @test_broken) — issue #70
@@ -27,9 +26,9 @@ run_qa(
     # ~14 reports are still surfaced as @test_broken rather than filtered out.
     jet_kwargs = (; target_defined_modules = true),
     aqua_kwargs = (; deps_compat = (check_extras = false,)),
-    aqua_broken = (:undefined_exports, :stale_deps),
+    aqua_broken = (:stale_deps,),
     jet_broken = true,
-    api_docs_kwargs = (; ignore = (:symbolic_steady_states,)),
+    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         all_qualified_accesses_are_public = (;
             ignore = (


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- remove the undefined `symbolic_steady_states` export instead of keeping a public-API docs ignore
- enable rendered public API docs QA through SciMLTesting v2.1
- add the remaining exported API entries to the rendered algorithm docs

## Verification
- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n- `/home/crackauc/.juliaup/bin/julia +release --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/repos/Optimization.jl --startup-file=no -e 'using Runic; exit(Runic.main(["--check", "src/CatalystNetworkAnalysis.jl", "test/qa/qa.jl"]))'`\n- `git diff --check`